### PR TITLE
Add React microsite for analysis tools

### DIFF
--- a/frontend-react/index.html
+++ b/frontend-react/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Claude Flow Microsite</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "claude-flow-microsite",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "chart.js": "^4.4.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend-react/src/App.tsx
+++ b/frontend-react/src/App.tsx
@@ -1,0 +1,230 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Chart,
+  LineController,
+  LineElement,
+  PointElement,
+  LinearScale,
+  CategoryScale,
+  DoughnutController,
+  ArcElement,
+  RadarController,
+  RadialLinearScale,
+} from 'chart.js';
+
+Chart.register(
+  LineController,
+  LineElement,
+  PointElement,
+  LinearScale,
+  CategoryScale,
+  DoughnutController,
+  ArcElement,
+  RadarController,
+  RadialLinearScale,
+);
+
+const endpointMap: Record<string, string> = {
+  performance_report: '/api/analysis/performance-report',
+  bottleneck_analyze: '/api/analysis/bottleneck-analyze',
+  token_usage: '/api/analysis/token-usage',
+  benchmark_run: '/api/analysis/benchmark-run',
+  metrics_collect: '/api/analysis/metrics-collect',
+  trend_analysis: '/api/analysis/trend-analysis',
+  cost_analysis: '/api/analysis/cost-analysis',
+  quality_assess: '/api/analysis/quality-assess',
+  error_analysis: '/api/analysis/error-analysis',
+  usage_stats: '/api/analysis/usage-stats',
+  health_check: '/api/analysis/health-check',
+  load_monitor: '/api/analysis/load-monitor',
+  capacity_plan: '/api/analysis/capacity-plan',
+};
+
+const tabs = ['metrics', 'reports', 'analysis', 'health'] as const;
+
+type Tab = (typeof tabs)[number];
+
+const toolGroups: Record<Tab, { id: string; label: string }[]> = {
+  metrics: [
+    { id: 'performance_report', label: 'Performance Report' },
+    { id: 'token_usage', label: 'Token Usage' },
+    { id: 'metrics_collect', label: 'Collect Metrics' },
+    { id: 'usage_stats', label: 'Usage Stats' },
+  ],
+  reports: [
+    { id: 'performance_report', label: 'Performance Report' },
+    { id: 'cost_analysis', label: 'Cost Analysis' },
+    { id: 'quality_assess', label: 'Quality Assess' },
+    { id: 'benchmark_run', label: 'Benchmark Run' },
+  ],
+  analysis: [
+    { id: 'bottleneck_analyze', label: 'Bottleneck Analysis' },
+    { id: 'trend_analysis', label: 'Trend Analysis' },
+    { id: 'error_analysis', label: 'Error Analysis' },
+    { id: 'capacity_plan', label: 'Capacity Plan' },
+  ],
+  health: [
+    { id: 'health_check', label: 'Health Check' },
+    { id: 'load_monitor', label: 'Load Monitor' },
+  ],
+};
+
+interface ResultMap {
+  [key: string]: any;
+}
+
+export default function App() {
+  const [activeTab, setActiveTab] = useState<Tab>('metrics');
+  const [results, setResults] = useState<ResultMap>({});
+  const perfChartRef = useRef<HTMLCanvasElement>(null);
+  const tokenChartRef = useRef<HTMLCanvasElement>(null);
+  const healthChartRef = useRef<HTMLCanvasElement>(null);
+  const loadChartRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const perfCtx = perfChartRef.current?.getContext('2d');
+    const tokenCtx = tokenChartRef.current?.getContext('2d');
+    const healthCtx = healthChartRef.current?.getContext('2d');
+    const loadCtx = loadChartRef.current?.getContext('2d');
+
+    let perfChart: Chart | undefined;
+    let tokenChart: Chart | undefined;
+    let healthChart: Chart | undefined;
+    let loadChart: Chart | undefined;
+
+    if (perfCtx) {
+      perfChart = new Chart(perfCtx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Response Time', data: [] }] },
+      });
+    }
+    if (tokenCtx) {
+      tokenChart = new Chart(tokenCtx, {
+        type: 'doughnut',
+        data: {
+          labels: ['Input', 'Output', 'Cached'],
+          datasets: [{ data: [0, 0, 0] }],
+        },
+      });
+    }
+    if (healthCtx) {
+      healthChart = new Chart(healthCtx, {
+        type: 'radar',
+        data: { labels: ['CPU', 'Memory', 'Disk', 'Network', 'API', 'DB'], datasets: [{ data: [100, 100, 100, 100, 100, 100] }] },
+        options: { scales: { r: { beginAtZero: true, max: 100 } } },
+      });
+    }
+    if (loadCtx) {
+      loadChart = new Chart(loadCtx, {
+        type: 'line',
+        data: { labels: [], datasets: [{ label: 'Load', data: [] }] },
+      });
+    }
+
+    const ws = new WebSocket(`${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/analysis/ws`);
+    ws.onmessage = (event) => {
+      const data = JSON.parse(event.data);
+      if (data.type === 'metrics_update') {
+        const { performance, tokens, health, load } = data.payload;
+        if (perfChart) {
+          const labels = perfChart.data.labels as string[];
+          labels.push('');
+          (perfChart.data.datasets[0].data as number[]).push(performance.responseTime);
+          if (labels.length > 20) {
+            labels.shift();
+            (perfChart.data.datasets[0].data as number[]).shift();
+          }
+          perfChart.update();
+        }
+        if (tokenChart) {
+          tokenChart.data.datasets[0].data = [tokens.inputTokens, tokens.outputTokens, tokens.cachedTokens];
+          tokenChart.update();
+        }
+        if (healthChart) {
+          healthChart.data.datasets[0].data = Object.values(health);
+          healthChart.update();
+        }
+        if (loadChart) {
+          const labels = loadChart.data.labels as string[];
+          labels.push('');
+          (loadChart.data.datasets[0].data as number[]).push(load.current);
+          if (labels.length > 20) {
+            labels.shift();
+            (loadChart.data.datasets[0].data as number[]).shift();
+          }
+          loadChart.update();
+        }
+      }
+    };
+
+    return () => {
+      ws.close();
+      perfChart?.destroy();
+      tokenChart?.destroy();
+      healthChart?.destroy();
+      loadChart?.destroy();
+    };
+  }, []);
+
+  const runTool = async (id: string) => {
+    const endpoint = endpointMap[id];
+    try {
+      const res = await fetch(endpoint);
+      const json = await res.json();
+      setResults((r) => ({ ...r, [id]: json }));
+    } catch (err) {
+      setResults((r) => ({ ...r, [id]: { error: String(err) } }));
+    }
+  };
+
+  return (
+    <div style={{ fontFamily: 'Arial, sans-serif', padding: 20 }}>
+      <h1>Claude Flow Analysis Tools</h1>
+      <nav style={{ marginBottom: 20 }}>
+        {tabs.map((tab) => (
+          <button
+            key={tab}
+            style={{ marginRight: 8, fontWeight: activeTab === tab ? 'bold' : 'normal' }}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab}
+          </button>
+        ))}
+      </nav>
+
+      <section>
+        {toolGroups[activeTab].map((tool) => (
+          <button key={tool.id} style={{ marginRight: 8, marginBottom: 8 }} onClick={() => runTool(tool.id)}>
+            {tool.label}
+          </button>
+        ))}
+      </section>
+
+      <div style={{ marginTop: 20 }}>
+        {activeTab === 'metrics' && (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 20 }}>
+            <canvas ref={perfChartRef} width={300} height={200}></canvas>
+            <canvas ref={tokenChartRef} width={200} height={200}></canvas>
+          </div>
+        )}
+        {activeTab === 'health' && (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 20 }}>
+            <canvas ref={healthChartRef} width={250} height={250}></canvas>
+            <canvas ref={loadChartRef} width={300} height={200}></canvas>
+          </div>
+        )}
+      </div>
+
+      <div style={{ marginTop: 20 }}>
+        {toolGroups[activeTab].map((tool) => (
+          <div key={tool.id} style={{ marginBottom: 20 }}>
+            <h3>{tool.label} Result</h3>
+            <pre style={{ background: '#f0f0f0', padding: 10 }}>
+              {JSON.stringify(results[tool.id], null, 2) || 'No data'}
+            </pre>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend-react/src/main.tsx
+++ b/frontend-react/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/frontend-react/tsconfig.json
+++ b/frontend-react/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "lib": ["DOM", "ESNext"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/frontend-react/vite.config.ts
+++ b/frontend-react/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: './',
+});


### PR DESCRIPTION
## Summary
- create `frontend-react` microsite using React and Vite
- implement charts and API interactions with the existing analysis routes
- WebSocket support for real‑time metrics

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885039e5e30832a98ffe0e587b87b90